### PR TITLE
Improve AC Control Logic

### DIFF
--- a/custom_components/nissan_carwings/manifest.json
+++ b/custom_components/nissan_carwings/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/remuslazar/homeassistant-carwings/issues",
   "requirements": [
-    "pycarwings3~=0.7.1"
+    "pycarwings3~=0.7.3"
   ],
   "single_config_entry": true,
   "version": "0.1.4"

--- a/custom_components/nissan_carwings/translations/de.json
+++ b/custom_components/nissan_carwings/translations/de.json
@@ -52,6 +52,9 @@
             },
             "electric_mileage": {
                 "name": "Tagesverbrauch"
+            },
+            "hvac_timer": {
+                "name": "Klima-Timer"
             }
         },
         "switch": {

--- a/custom_components/nissan_carwings/translations/en.json
+++ b/custom_components/nissan_carwings/translations/en.json
@@ -53,6 +53,9 @@
             },
             "electric_mileage": {
                 "name": "Daily Efficiency"
+            },
+            "hvac_timer": {
+                "name": "AC Timer"
             }
         },
         "switch": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
-homeassistant==2024.6.0
+homeassistant==2024.8.2
 pip>=21.3.1
 ruff==0.5.5


### PR DESCRIPTION
This improves the current AC control logic and also adds an additional sensor HVACTimerSensor to show the current AC remaining running time (currently fixed to 15 minutes when running on battery or 2 hours when being plugged).

Fixes #13 