### PR TITLE
Refactor API/DataCoordinator types and imports

### DIFF
--- a/custom_components/nissan_carwings/const.py
+++ b/custom_components/nissan_carwings/const.py
@@ -21,6 +21,9 @@ UPDATE_INTERVAL_WHILE_AWAITING_UPDATE = 60
 DEFAULT_POLL_INTERVAL = 7200
 DEFAULT_POLL_INTERVAL_CHARGING = 900
 
+# we will use this poll interval when the last update has failed to avoid hammering the API with too many requests
+POLL_INTERVAL_WHEN_FAILED = 900
+
 DATA_BATTERY_STATUS_KEY = "battery_status"
 DATA_CLIMATE_STATUS_KEY = "climate_status"
 DATA_DRIVING_ANALYSIS_KEY = "driving_analysis"


### PR DESCRIPTION
The API component should return the real objects and not [str: Any]. Also cleanup imports and other stuff and rework the "retry when failed" logic to avoid hammering the API with the many requests when the service is not available for a longer period of time.