### PR TITLE
Handle missing data and API hiccups greacefully

### DIFF
--- a/custom_components/nissan_carwings/binary_sensor.py
+++ b/custom_components/nissan_carwings/binary_sensor.py
@@ -52,13 +52,12 @@ class LeafPluggedInSensor(NissanCarwingsEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.unique_id_prefix}_{self.entity_description.key}"
 
     @property
-    def available(self) -> bool:
-        """Sensor availability."""
-        return self.coordinator.data[DATA_BATTERY_STATUS_KEY].is_connected is not None
-
-    @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if plugged in."""
+
+        if self.coordinator.data[DATA_BATTERY_STATUS_KEY] is None:
+            return None
+
         return bool(self.coordinator.data[DATA_BATTERY_STATUS_KEY].is_connected)
 
 
@@ -78,11 +77,10 @@ class LeafChargingSensor(NissanCarwingsEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.unique_id_prefix}_{self.entity_description.key}"
 
     @property
-    def available(self) -> bool:
-        """Sensor availability."""
-        return self.coordinator.data[DATA_BATTERY_STATUS_KEY].is_charging is not None
-
-    @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if charging."""
+
+        if self.coordinator.data[DATA_BATTERY_STATUS_KEY] is None:
+            return None
+
         return bool(self.coordinator.data[DATA_BATTERY_STATUS_KEY].is_charging)

--- a/custom_components/nissan_carwings/manifest.json
+++ b/custom_components/nissan_carwings/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/remuslazar/homeassistant-carwings/issues",
   "requirements": [
-    "pycarwings3~=0.7.5"
+    "pycarwings3~=0.7.6"
   ],
   "single_config_entry": true,
   "version": "0.2.1"


### PR DESCRIPTION
Handle the case when the API does not deliver any data gracefully. This PR also bumps the pycarwings3 dependency to 0.7.6.

Do not render the sensor entities unavailable when there is no data from remote, use the "unknown" value instead.

Resolves https://github.com/remuslazar/homeassistant-carwings/issues/45